### PR TITLE
init.rc: move load_system_props to beginning of 'on fs'

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -246,10 +246,6 @@ on property:sys.boot_from_charger_mode=1
     class_stop charger
     trigger late-init
 
-# Load properties from /system/ + /factory after fs mount.
-on load_system_props_action
-    load_system_props
-
 on load_persist_props_action
     load_persist_props
     start logd
@@ -269,11 +265,6 @@ on late-init
     # while /data is optional.
     trigger fs
     trigger post-fs
-
-    # Load properties from /system/ + /factory after fs mount. Place
-    # this in another action so that the load will be scheduled after the prior
-    # issued fs triggers have completed.
-    trigger load_system_props_action
 
     # Mount fstab in init.{$device}.rc by mount_all with '--late' parameter
     # to only mount entries with 'latemount'. This is needed if '--early' is
@@ -297,6 +288,13 @@ on late-init
 
 
 on post-fs
+    # Load properties from
+    #     /system/build.prop,
+    #     /odm/build.prop,
+    #     /vendor/build.prop and
+    #     /factory/factory.prop
+    load_system_props
+    # start essential services
     start logd
     # once everything is setup, no need to modify /
     mount rootfs rootfs / ro remount


### PR DESCRIPTION
ro.logd.kernel, ro.config.low_ram, ro.logd.timestamp and ro.debuggable
need to be retrieved prior to logd start in order for the service to
behave in a configured manner.  Other essential services are also
dependent on these system properties as well, so it just makes sense
to pick them all up first in 'on fs'.

Test: smoke test
Bug: 37425809
Change-Id: I33ad185f397ee527ed3c84cc2bcb40ff8ca785b5